### PR TITLE
add conditional mkdirSync

### DIFF
--- a/src/utils/file.ts
+++ b/src/utils/file.ts
@@ -26,7 +26,7 @@ export function validateAndNormalizeFilename(filePath: string): string {
     const fileName = path.basename(filePath);
     const basePath = filePath.replace(fileName, '') + '__fixtures__/';
     try {
-        fs.mkdirSync(basePath);
+        if (!fs.existsSync(basePath)) fs.mkdirSync(basePath);
     } catch (error) {
         throw new Error(
             ERROR_MESSAGES.DIR_WRITE.replace(':filePath', basePath).replace(

--- a/tests/utils.spec.ts
+++ b/tests/utils.spec.ts
@@ -521,6 +521,7 @@ describe('validateAndNormalizeFilename', () => {
             );
         });
         it('an error fixture dir cannot be created', () => {
+            existsSyncSpy.mockImplementationOnce(() => false);
             mkdirSyncSpy.mockImplementationOnce(() => {
                 throw new Error('');
             });
@@ -536,6 +537,18 @@ describe('validateAndNormalizeFilename', () => {
     });
 
     describe('correctly', () => {
+        it('creates __fixtures__ dir if it does not exist', () => {
+            existsSyncSpy.mockReturnValueOnce(false);
+            validateAndNormalizeFilename('/imaginary/path/name');
+            expect(mkdirSyncSpy).toHaveBeenCalled();
+            existsSyncSpy.mockReset();
+        });
+        it('does not throw if __fixtures__ dir already exists', () => {
+            expect(() =>
+                validateAndNormalizeFilename('/imaginary/path/name'),
+            ).not.toThrow();
+            expect(mkdirSyncSpy).not.toHaveBeenCalled();
+        });
         it('detects a file name at the end of the file path', () => {
             existsSyncSpy.mockReturnValueOnce(true);
             expect(


### PR DESCRIPTION
Sadly there still was a bug: fs.mkdirSync throws an error if the dir already exists.
I am trying to add more thorough tests with every commit, maybe you'd also like to take it for a spin before the next release?