### PR TITLE
Ignore values undefined when comparing objects

### DIFF
--- a/src/utils/file.ts
+++ b/src/utils/file.ts
@@ -83,7 +83,6 @@ export function writeFixtureFile<T>(
 export function mapKeyPaths<T>(input: T, parent = ''): string[] {
     const keys = [];
     for (let [key, value] of Object.entries(input)) {
-        keys.push(key);
         let subChain = parent ? `${parent}.${key}` : key;
         if (Array.isArray(value)) {
             let [nestedValue, levels] = getValueFromNestedArray(value, 1);
@@ -95,7 +94,7 @@ export function mapKeyPaths<T>(input: T, parent = ''): string[] {
         }
         if (isRecord(value)) {
             keys.push(...mapKeyPaths(value, subChain));
-        } else {
+        } else if (value !== undefined) {
             keys.push(subChain);
         }
     }

--- a/src/utils/file.ts
+++ b/src/utils/file.ts
@@ -81,8 +81,11 @@ export function writeFixtureFile<T>(
 }
 
 export function mapKeyPaths<T>(input: T, parent = ''): string[] {
-    const keys = [];
+    const keys: string[] = [];
     for (let [key, value] of Object.entries(input)) {
+        if (value !== undefined) {
+            keys.push(key);
+        }
         let subChain = parent ? `${parent}.${key}` : key;
         if (Array.isArray(value)) {
             let [nestedValue, levels] = getValueFromNestedArray(value, 1);

--- a/tests/utils/file.spec.ts
+++ b/tests/utils/file.spec.ts
@@ -125,11 +125,19 @@ describe('isSameStructure', () => {
     it('returns true if structure matches', () => {
         expect(isSameStructure(defaults, defaults)).toEqual(true);
     });
-    it('returns false if structure does not match', () => {
+    it('ignores undefined values in comparison', () => {
         expect(
             isSameStructure(defaults, {
                 ...defaults,
                 children: undefined,
+            }),
+        ).toEqual(true);
+    });
+    it('returns false if structure does not match', () => {
+        expect(
+            isSameStructure(defaults, {
+                ...defaults,
+                children: [1, 2, 3],
             }),
         ).toEqual(false);
     });


### PR DESCRIPTION
I found an issue with how undefined is handled.

This code would be expected to output the same number twice.
```typescript
import { FixtureFactory } from 'interface-forge';
type TestType = {
    foo: number;
    bar?: number;
};
const TestFactory = new FixtureFactory<TestType>(() => {
    return {
        bar: undefined,
        foo: Math.random(),
    };
});
console.log(TestFactory.fixtureSync(__dirname + '/test.json').foo);
console.log(TestFactory.fixtureSync(__dirname + '/test.json').foo);
```

But the output is something like this
```
0.11248577962948514
0.9229428259261987
```

The reason is that `undefined` is lost when serializing to JSON.

This PR fixes this issue by _ignoring_ undefined values. This does not work, if the factory sometimes generates a value and sometimes it generated `undefined`. If this is a priority, please let me know and I can come up with a solution.